### PR TITLE
Refactor service class as an interface

### DIFF
--- a/cmd/webanalyzer/main.go
+++ b/cmd/webanalyzer/main.go
@@ -4,13 +4,16 @@ import (
 	"log"
 
 	"github.com/GayanB90/go-web-analyzer/internal/handler"
+	"github.com/GayanB90/go-web-analyzer/internal/service"
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
 	router := gin.Default()
 
-	router.POST("/analyze", handler.AnalyzePageHandler)
+	analysisService := &service.DefaultWebPageAnalysisService{}
+
+	router.POST("/analyze", handler.GetAnalyzePageHandler(analysisService))
 	err := router.Run(":8080")
 	if err != nil {
 		log.Fatal("Server exited with error: ", err)

--- a/internal/handler/analyze_page_handler.go
+++ b/internal/handler/analyze_page_handler.go
@@ -9,19 +9,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func AnalyzePageHandler(c *gin.Context) {
-	var webAnalysisRequest dto.WebAnalysisRequest
+func GetAnalyzePageHandler(pageAnalysisService service.WebPageAnalysisService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var webAnalysisRequest dto.WebAnalysisRequest
 
-	if err := c.BindJSON(&webAnalysisRequest); err != nil {
-		return
+		if err := c.BindJSON(&webAnalysisRequest); err != nil {
+			return
+		}
+		log.Printf("Binding web analysisRequest successful: %v", webAnalysisRequest)
+
+		webAnalysisRequestModel := dto.ToWebAnalysisRequestModel(webAnalysisRequest)
+		log.Printf("Initiating web page analysis for the request model %v", webAnalysisRequestModel)
+		webAnalysisResultModel := pageAnalysisService.AnalyzeWebPage(webAnalysisRequestModel)
+		log.Printf("Successfully analyzed the page for the request model %v, result: %v", webAnalysisRequestModel, webAnalysisResultModel)
+		webAnalysisResponse := dto.ToWebAnalysisResponseDto(webAnalysisResultModel)
+		log.Printf("Web Analysis Response: %v", webAnalysisResponse)
+		c.IndentedJSON(http.StatusOK, webAnalysisResponse)
 	}
-	log.Printf("Binding web analysisRequest successful: %v", webAnalysisRequest)
-
-	webAnalysisRequestModel := dto.ToWebAnalysisRequestModel(webAnalysisRequest)
-	log.Printf("Initiating web page analysis for the request model %v", webAnalysisRequestModel)
-	webAnalysisResultModel := service.AnalyzeWebPage(webAnalysisRequestModel)
-	log.Printf("Successfully analyzed the page for the request model %v, result: %v", webAnalysisRequestModel, webAnalysisResultModel)
-	webAnalysisResponse := dto.ToWebAnalysisResponseDto(webAnalysisResultModel)
-	log.Printf("Web Analysis Response: %v", webAnalysisResponse)
-	c.IndentedJSON(http.StatusOK, webAnalysisResponse)
 }

--- a/internal/service/default_web_page_analysis_service.go
+++ b/internal/service/default_web_page_analysis_service.go
@@ -9,7 +9,9 @@ import (
 	"golang.org/x/net/html"
 )
 
-func AnalyzeWebPage(request model.WebAnalysisRequestModel) model.WebAnalysisResultModel {
+type DefaultWebPageAnalysisService struct{}
+
+func (s *DefaultWebPageAnalysisService) AnalyzeWebPage(request model.WebAnalysisRequestModel) model.WebAnalysisResultModel {
 	var urlString = request.WebUrl
 
 	err := utils.ValidateURL(urlString)

--- a/internal/service/web_page_analysis_service.go
+++ b/internal/service/web_page_analysis_service.go
@@ -1,0 +1,7 @@
+package service
+
+import "github.com/GayanB90/go-web-analyzer/internal/model"
+
+type WebPageAnalysisService interface {
+	AnalyzeWebPage(webPage model.WebAnalysisRequestModel) model.WebAnalysisResultModel
+}


### PR DESCRIPTION
Refactor service class as an interface and then inject an object of DefaultWebPageAnalysisService into the gin handler func for better decoupling of business logic to handler func