### PR TITLE
Add broken link detection to the default web page analysis service

### DIFF
--- a/internal/service/http_url_validation_service.go
+++ b/internal/service/http_url_validation_service.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"log"
+	"net/http"
+)
+
+type HttpUrlValidationService struct{}
+
+func (service *HttpUrlValidationService) ValidateUrl(url string) (err error) {
+	log.Printf("invoking GET request for URL %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	log.Printf("finished invoking GET request for URL %s", url)
+	defer resp.Body.Close()
+	return nil
+}

--- a/internal/service/lexical_url_validation_service.go
+++ b/internal/service/lexical_url_validation_service.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"log"
+
+	"github.com/GayanB90/go-web-analyzer/pkg/utils"
+)
+
+type LexicalUrlValidationService struct{}
+
+func (service *LexicalUrlValidationService) ValidateUrl(url string) (err error) {
+	log.Printf("Parsing the URL %s", url)
+	err = utils.ValidateURL(url)
+	if err != nil {
+		log.Printf("Failed to parse the URL %s, error: %v", url, err.Error())
+		return err
+	}
+	return nil
+}

--- a/internal/service/url_validation_service.go
+++ b/internal/service/url_validation_service.go
@@ -1,0 +1,5 @@
+package service
+
+type UrlValidationService interface {
+	ValidateUrl(url string) (err error)
+}


### PR DESCRIPTION
This feature adds two default ways of finding broken links on a web page. Once the hyperlinks have been detected, the default web page analysis service will analyze the link URLs' lexically and over the wire with GET requests in this order respectively. Lexical analysis is performed first to avoid any unnecessary HTTP invocations.